### PR TITLE
Do not split the return value from get_include()

### DIFF
--- a/ups/numpy.cfg
+++ b/ups/numpy.cfg
@@ -19,11 +19,13 @@ class Configuration(lsst.sconsUtils.Configuration):
     def configure(self, conf, packages, check=False, build=True):
         lsst.sconsUtils.log.info("Configuring package '%s'." % self.name)
         try:
+            # Returns the path to a single include directory
             output = subprocess.check_output(["python", "-c",
                                               "import numpy; print(numpy.get_include())"]).decode()
+            output = output.strip()
         except subprocess.CalledProcessError:
             return False
-        conf.env.AppendUnique(XCPPPATH=output.split())
+        conf.env.AppendUnique(XCPPPATH=[output])
         return True
 
 config = Configuration()


### PR DESCRIPTION
It is documented to return a single path.